### PR TITLE
Fix multiple arg handling for #is

### DIFF
--- a/spec/route_spec.cr
+++ b/spec/route_spec.cr
@@ -209,6 +209,27 @@ describe Armature::Route do
     end.call make_context(method: "GET", path: "/top_level")
   end
 
+  it "matches arguments to `is`" do
+    # Spec expectations are inside the app
+    RouteTest.new do |r, response, session|
+      r.root { raise "This is not a request for '/'" }
+      r.handled?.should eq false
+
+      r.on "top_level" do
+        # `on` does not mark a request as handled
+        r.handled?.should eq false
+
+        # `is` does mark a request as handled
+        r.is String, Int64 do |arg, arg2|
+          arg.should eq "test"
+          arg2.should eq 321
+        end
+
+        r.handled?.should eq true
+      end
+    end.call make_context(method: "GET", path: "/top_level/test/321")
+  end
+
   it "treats a trailing slash as if it weren't there" do
     path = nil
 

--- a/src/route.cr
+++ b/src/route.cr
@@ -76,6 +76,21 @@ module Armature
 
       handle_method get, post, put, patch, delete
 
+      def is
+        return if handled?
+
+        old_path = original_request.path
+        begin
+          yield
+        ensure
+          handled!
+        end
+      ensure
+        if old_path
+          original_request.path = old_path
+        end
+      end
+
       def is(*segments)
         return if handled?
 
@@ -89,9 +104,9 @@ module Armature
           end
         end
 
-        if captures || segments.empty?
+        if captures
           begin
-            captures ? yield *captures : yield
+            yield *captures
           ensure
             handled!
           end
@@ -140,7 +155,7 @@ module Armature
         {% end %}
       {% end %}
 
-      def match?(segment : String, matcher : Symbol)
+      def match?(segment : String, matcher : Symbol | String.class)
         segment
       end
 


### PR DESCRIPTION
I didn't go all the way with multiple args for `#is`. This fixes that.